### PR TITLE
Cloud config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN dpkg --add-architecture i386 && \
 
 COPY ./bin /var/www/mohh-uhs
 COPY ./start_uhs_instances.sh /var/www/mohh-uhs/start_uhs_instances.sh
+COPY ./maplist.txt /var/www/mohh-uhs/maplist.txt
 COPY ./mohh-uhs.service /etc/systemd/system/mohh-uhs.service
 COPY ./mohh-uhs.timer /etc/systemd/system/mohh-uhs.timer
 
@@ -16,5 +17,4 @@ RUN mkdir -p /var/log/mohh-uhs && \
     chmod +x /var/www/mohh-uhs/start_uhs_instances.sh && \
     systemctl enable mohh-uhs.timer
 
-VOLUME /var/www/mohh-uhs/maplist.txt
 ENTRYPOINT ["/lib/systemd/systemd"]

--- a/maplist.txt
+++ b/maplist.txt
@@ -1,2 +1,2 @@
--gname:"[EU] TEAM MIX" -aa -ff:0 -maxPlayers:32 -mapList:352,153,245,341,222,324,124,211,115,216,132,336,131 -rounds:-1 -timeLimit:15 -DMLimit:0 -INFLimit:0 -HTLLimit:0 -BLLimit:0 -skipporttest
--gname:"[EU] DM" -aa -ff:0 -maxPlayers:32 -mapList:384,182,283,185,281,383,183,285,181,382,282,386,381,184,286 -rounds:-1 -timeLimit:15 -DMLimit:0 -INFLimit:0 -HTLLimit:0 -BLLimit:0 -skipporttest
+-gname:"[TMP] TEAM MIX" -ranked -aa -ff:0 -maxPlayers:32 -mapList:211,115,216,132,336,131,352,153,245,341,222,324,124 -rounds:1 -timeLimit:10 -DMLimit:0 -INFLimit:0 -HTLLimit:0 -BLLimit:0 -skipporttest
+-gname:"[TMP] DM" -ranked -aa -ff:0 -maxPlayers:32 -mapList:181,382,282,386,381,184,286,384,182,283,185,281,383,183,285 -rounds:1 -timeLimit:10 -DMLimit:0 -INFLimit:0 -HTLLimit:0 -BLLimit:0 -skipporttest


### PR DESCRIPTION
Move the `maplist.txt` file directly in the container, allowing an easier deployment in cloud services.