### PR TITLE
Continue rotation after crash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,17 @@ RUN dpkg --add-architecture i386 && \
 
 COPY ./bin /var/www/mohh-uhs
 COPY ./start_uhs_instances.sh /var/www/mohh-uhs/start_uhs_instances.sh
+COPY ./monitor_map_rotation.sh /var/www/mohh-uhs/monitor_map_rotation.sh
 COPY ./maplist.txt /var/www/mohh-uhs/maplist.txt
 COPY ./mohh-uhs.service /etc/systemd/system/mohh-uhs.service
 COPY ./mohh-uhs.timer /etc/systemd/system/mohh-uhs.timer
+COPY ./monitor-map-rotation.service /etc/systemd/system/monitor-map-rotation.service
 
 RUN mkdir -p /var/log/mohh-uhs && \
     touch /var/log/mohh-uhs/mohz.log && \
     chmod +x /var/www/mohh-uhs/start_uhs_instances.sh && \
-    systemctl enable mohh-uhs.timer
+    chmod +x /var/www/mohh-uhs/monitor_map_rotation.sh && \
+    systemctl enable mohh-uhs.timer && \
+    systemctl enable monitor-map-rotation.service
 
 ENTRYPOINT ["/lib/systemd/systemd"]

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ When running the container, you need to specify the following environment variab
 - `UHS_PWD`: The password of the account used to run the server
 - `UHS_ADMIN_PWD`: The password to access the admin menu in the game
 - `UHS_PORT`: The base port of the server, defaults to 3658. Every instance will use a port starting from this one
+- `UHS_LOC`: The location of the server. This will affect the game names of `maplist.txt` by overriding the "[LOC]" placeholder on the fly. E.g. with UHS_LOC = US and -gname:"[LOC] TEAM MIX", it will appear as "[US] TEAM MIX".
 
 You also need to mount a volume to `/var/www/mohh-uhs/maplist.txt` which contains the list of games to be hosted on the server (an example is provided in the project).  
 

--- a/maplist.txt
+++ b/maplist.txt
@@ -1,2 +1,2 @@
--gname:"[TMP] TEAM MIX" -ranked -aa -ff:0 -maxPlayers:32 -mapList:211,115,216,132,336,131,352,153,245,341,222,324,124 -rounds:1 -timeLimit:10 -DMLimit:0 -INFLimit:0 -HTLLimit:0 -BLLimit:0 -skipporttest
--gname:"[TMP] DM" -ranked -aa -ff:0 -maxPlayers:32 -mapList:181,382,282,386,381,184,286,384,182,283,185,281,383,183,285 -rounds:1 -timeLimit:10 -DMLimit:0 -INFLimit:0 -HTLLimit:0 -BLLimit:0 -skipporttest
+-gname:"[LOC] TEAM MIX" -ranked -aa -ff:0 -maxPlayers:32 -mapList:352,153,245,341,222,324,124,211,115,216,132,336,131 -rounds:1 -timeLimit:10 -DMLimit:0 -INFLimit:0 -HTLLimit:0 -BLLimit:0 -skipporttest
+-gname:"[LOC] DM" -ranked -aa -ff:0 -maxPlayers:32 -mapList:384,182,283,185,281,383,183,285,181,382,282,386,381,184,286 -rounds:1 -timeLimit:10 -DMLimit:0 -INFLimit:0 -HTLLimit:0 -BLLimit:0 -skipporttest

--- a/mohh-uhs.service
+++ b/mohh-uhs.service
@@ -4,7 +4,7 @@ Description=Start MOHH UHS Instances
 [Service]
 KillMode=none
 Type=oneshot
-PassEnvironment=UHS_NAME UHS_PWD UHS_ADM_PWD UHS_PORT UHS_INSTANCES
+PassEnvironment=UHS_NAME UHS_PWD UHS_ADM_PWD UHS_PORT UHS_LOC
 Environment=WINEDEBUG=-all
 WorkingDirectory=/var/www/mohh-uhs
 ExecStart=/var/www/mohh-uhs/start_uhs_instances.sh

--- a/mohh-uhs.timer
+++ b/mohh-uhs.timer
@@ -3,7 +3,7 @@ Description=Run MOHH UHS Instances periodically
 
 [Timer]
 OnBootSec=0
-OnUnitActiveSec=5min
+OnUnitActiveSec=15
 Unit=mohh-uhs.service
 
 [Install]

--- a/monitor-map-rotation.service
+++ b/monitor-map-rotation.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Monitor MOHZ map rotation and update maplist.txt
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/var/www/mohh-uhs/monitor_map_rotation.sh
+Restart=always
+User=root
+
+[Install]
+WantedBy=multi-user.target

--- a/monitor-map-rotation.service
+++ b/monitor-map-rotation.service
@@ -5,6 +5,8 @@ After=network.target
 [Service]
 Type=simple
 ExecStart=/var/www/mohh-uhs/monitor_map_rotation.sh
+StandardOutput=append:/var/log/mohh-uhs/monitor_map_rotation.log
+StandardError=append:/var/log/mohh-uhs/monitor_map_rotation.log
 Restart=always
 User=root
 

--- a/monitor_map_rotation.sh
+++ b/monitor_map_rotation.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# Script to monitor mohz.exe log files and shift maplist.txt when a map rotation occurs
+# Usage: ./monitor_map_rotation.sh
+
+LOG_DIR="/var/log/mohh-uhs"
+MAPLIST="/var/www/mohh-uhs/maplist.txt"
+
+# Ensure UHS_PORT is set to default if not provided
+export UHS_PORT=${UHS_PORT:-3668}
+
+# Function to get the maplist.txt line for a given port
+get_maplist_line_for_port() {
+    local port="$1"
+    local idx=$((port - UHS_PORT))
+    grep -v '^#' "$MAPLIST" | grep -v '^$' | sed -n "$((idx+1))p"
+}
+
+# Function to shift the mapList in a maplist.txt line
+shift_maplist() {
+    local line="$1"
+    local cycled_map="$2"
+    # Extract the mapList
+    local maplist=$(echo "$line" | grep -oP '(?<=-mapList:)[^ ]+')
+    IFS=',' read -ra maps <<< "$maplist"
+    idx=-1
+    for i in "${!maps[@]}"; do
+        map_trimmed=$(echo "${maps[$i]}" | xargs)
+        if [[ "$map_trimmed" == "$cycled_map" ]]; then
+            idx=$i
+            break
+        fi
+    done
+    if [[ $idx -ge 0 ]]; then
+        new_maps=()
+        for ((j=idx; j<${#maps[@]}; j++)); do
+            new_maps+=("${maps[$j]}")
+        done
+        for ((j=0; j<idx; j++)); do
+            new_maps+=("${maps[$j]}")
+        done
+        new_maplist=$(IFS=, ; echo "${new_maps[*]}")
+        new_line=$(echo "$line" | sed "s/-mapList:[^ ]*/-mapList:$new_maplist/")
+        echo "$new_line"
+    else
+        echo "$line"
+    fi
+}
+
+# Function to check if a port is present in any mapList in maplist.txt
+port_in_any_maplist() {
+    local port="$1"
+    grep -oP '(?<=-mapList:)[^ ]+' "$MAPLIST" | tr ',' '\n' | grep -qx "$port"
+}
+
+# Dynamic watcher: monitor new log files as they appear
+
+declare -A tailed_files
+
+echo "[DEBUG] Script started, UHS_PORT=$UHS_PORT, LOG_DIR=$LOG_DIR"
+
+while true; do
+    for logfile in "$LOG_DIR"/uhs_instance_*.log; do
+        if [ -f "$logfile" ] && [ -z "${tailed_files[$logfile]}" ]; then
+            echo "[DEBUG] Launching tail for $logfile"
+            tailed_files["$logfile"]=1
+            {
+                port=$(echo "$logfile" | grep -oE '[0-9]+')
+                echo "[DEBUG] [$port] Tail process started for $logfile"
+                tail -f "$logfile" 2>/dev/null | while read -r line; do
+                    echo "[DEBUG] [$port] Raw line: [$line]"
+                    if [[ "$line" == *"Server cycling to map"* ]]; then
+                        echo "[DEBUG] [$port] Substring match: $line"
+                        mapnum=$(echo "$line" | grep -oE "Server cycling to map '?([0-9]+)'?" | grep -oE "[0-9]+")
+                        echo "[DEBUG] [$port] Extracted map number: $mapnum"
+                        cycled_map="$mapnum"
+                        map_line=$(get_maplist_line_for_port "$port")
+                        echo "[DEBUG] [$port] Using maplist line: $map_line"
+                        new_map_line=$(shift_maplist "$map_line" "$cycled_map")
+                        if [[ "$new_map_line" != "$map_line" ]]; then
+                            echo "[DEBUG] [$port] Cycled map found in maplist, updating maplist..."
+                            tmpfile=$(mktemp)
+                            replaced=0
+                            line_num=0
+                            while IFS= read -r l; do
+                                if [[ $replaced -eq 0 && ! "$l" =~ ^# && ! -z "$l" ]]; then
+                                    if [[ $line_num -eq $((port - UHS_PORT)) ]]; then
+                                        echo "$new_map_line" >> "$tmpfile"
+                                        replaced=1
+                                    else
+                                        echo "$l" >> "$tmpfile"
+                                    fi
+                                    ((line_num++))
+                                else
+                                    echo "$l" >> "$tmpfile"
+                                fi
+                            done < "$MAPLIST"
+                            mv "$tmpfile" "$MAPLIST"
+                            echo "[DEBUG] [$port] maplist.txt updated: $new_map_line"
+                        else
+                            echo "[DEBUG] [$port] Cycled map $cycled_map not in maplist.txt, no update"
+                        fi
+                    fi
+                done
+                echo "[DEBUG] [$port] Tail process for $logfile exiting"
+            } &
+        fi
+    done
+    sleep 2
+done
+wait

--- a/monitor_map_rotation.sh
+++ b/monitor_map_rotation.sh
@@ -67,7 +67,7 @@ while true; do
                 port=$(echo "$logfile" | grep -oE '[0-9]+')
                 echo "[DEBUG] [$port] Tail process started for $logfile"
                 tail -f "$logfile" 2>/dev/null | while read -r line; do
-                    echo "[DEBUG] [$port] Raw line: [$line]"
+                    echo "[DEBUG] [$port] Raw line: $line"
                     if [[ "$line" == *"Server cycling to map"* ]]; then
                         echo "[DEBUG] [$port] Substring match: $line"
                         mapnum=$(echo "$line" | grep -oE "Server cycling to map '?([0-9]+)'?" | grep -oE "[0-9]+")

--- a/start_uhs_instances.sh
+++ b/start_uhs_instances.sh
@@ -25,7 +25,8 @@ start_instance() {
         -pwd:"$UHS_PWD" \
         -port:"$port" \
         -adminpwd:"$UHS_ADM_PWD" \
-        "${args[@]}" &
+        -logging \
+        "${args[@]}" > "/var/log/mohh-uhs/uhs_instance_${port}.log" 2>&1 &
 }
 
 check_instance() {

--- a/start_uhs_instances.sh
+++ b/start_uhs_instances.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-if [ -z "$UHS_NAME" ] || [ -z "$UHS_PWD" ] || [ -z "$UHS_ADM_PWD" ]; then
+if [ -z "$UHS_NAME" ] || [ -z "$UHS_PWD" ] || [ -z "$UHS_ADM_PWD" ] || [ -z "$UHS_LOC" ]; then
     echo "One or more mandatory environment variables are not set"
     exit 1
 fi
 
-export UHS_PORT=${UHS_PORT:-3658}
+export UHS_PORT=${UHS_PORT:-3668}
 
 if [ ! -d "/root/.wine" ]; then
    winecfg > /dev/null 2>&1
@@ -78,8 +78,14 @@ while IFS= read -r line || [ -n "$line" ]; do
         continue
     fi
 
+
+    # Replace [LOC] with [$UHS_LOC] in the line if UHS_LOC is set (in memory only)
+    localized_line="$line"
+    if [ -n "$UHS_LOC" ]; then
+        localized_line="${localized_line//\[LOC\]/[${UHS_LOC}]}"
+    fi
     # Read the line into an array, handling quoted strings
-    eval "args=($line)"
+    eval "args=($localized_line)"
 
     if ! check_instance "$port" "${args[@]}"; then
         start_instance "$port" "${args[@]}"


### PR DESCRIPTION
- Closes #1 - Continue the map rotation after a crash
- Update the timer for a quick restart after crash (15 sec instead of 5 min)
- Add UHS_LOC variable to indicate the location of the server in the brackets (replaces 'LOC' in the `maplist.txt`)
- Remove instance restart on arguments change (conflicts with this feature given the maplist update)